### PR TITLE
Fix: "NotImplementedError: Class 'QScreen' cannot be instantiated"

### DIFF
--- a/src/view.py
+++ b/src/view.py
@@ -9,7 +9,7 @@ from PySide6.QtWidgets import (
 )
 from PySide6.QtMultimedia import QMediaPlayer, QAudioOutput
 from PySide6.QtCore import Signal, Qt, QUrl, QSize
-from PySide6.QtGui import QPixmap, QAction, QScreen, QTextOption
+from PySide6.QtGui import QPixmap, QAction, QTextOption, QGuiApplication
 
 import os
 import json
@@ -865,7 +865,8 @@ class AudiobookMakerView(QMainWindow):
 
         # Window settings
         self.setWindowTitle("Audiobook Maker")
-        screen = QScreen().availableGeometry()  # Get the available screen geometry
+        app_screen = QGuiApplication.primaryScreen()
+        screen   = app_screen.availableGeometry() # Get the available screen geometry
         target_ratio = 16 / 9
 
         width = screen.width() * 0.8  # Adjusted to fit within the screen


### PR DESCRIPTION
Fix this exception:
```
Traceback (most recent call last):
  File "D:\audiobook_maker\src\controller.py", line 930, in <module>
    controller = AudiobookController()
                 ^^^^^^^^^^^^^^^^^^^^^
  File "D:\audiobook_maker\src\controller.py", line 127, in __init__
    self.view = AudiobookMakerView()
                ^^^^^^^^^^^^^^^^^^^^
  File "D:\audiobook_maker\src\view.py", line 546, in __init__
    self._init_ui()
  File "D:\audiobook_maker\src\view.py", line 868, in _init_ui
    screen = QScreen().availableGeometry()  # Get the available screen geometry
             ^^^^^^^^^
NotImplementedError: Class 'QScreen' cannot be instantiated.
```
---
https://github.com/JarodMica/audiobook_maker/issues/138