### PR TITLE
Add Camb AI as a TTS engine option

### DIFF
--- a/configs/tts_config.json
+++ b/configs/tts_config.json
@@ -562,6 +562,74 @@
                     "step": 100
                 }
             ]
+        },
+        {
+            "name": "Camb_AI",
+            "upload_params": {
+                "AI Models": [],
+                "Voice Reference File": [
+                    {
+                        "label": "Voice Name",
+                        "type": "text",
+                        "attribute": "upload_camb_ai_voice_name"
+                    },
+                    {
+                        "label": "Browse Reference Audio",
+                        "type": "file",
+                        "attribute": "upload_camb_ai_voice_ref_path",
+                        "file_filter": "Audio Files (*.wav *.mp3 *.flac *.ogg);;All Files (*)",
+                        "save_path": "voices/camb_ai",
+                        "save_format": "folder"
+                    }
+                ]
+            },
+            "parameters": [
+                {
+                    "label": "API Key",
+                    "type": "text",
+                    "attribute": "camb_ai_api_key"
+                },
+                {
+                    "label": "Speech Model",
+                    "type": "combobox",
+                    "attribute": "camb_ai_speech_model",
+                    "function": "get_combobox_items",
+                    "folder_path": "",
+                    "look_for": "custom",
+                    "custom_options": ["mars-flash", "mars-pro", "mars-instruct"]
+                },
+                {
+                    "label": "Voice ID",
+                    "type": "spinbox",
+                    "attribute": "camb_ai_voice_id",
+                    "min": 0,
+                    "max": 9999999,
+                    "default": 147320
+                },
+                {
+                    "label": "Language",
+                    "type": "combobox",
+                    "attribute": "camb_ai_language",
+                    "function": "get_combobox_items",
+                    "folder_path": "",
+                    "look_for": "custom",
+                    "custom_options": ["en-us", "es-es", "fr-fr", "de-de", "ja-jp", "hi-in", "pt-br", "zh-cn", "ko-kr", "it-it", "nl-nl", "ru-ru", "ar-sa"]
+                },
+                {
+                    "label": "Output Format",
+                    "type": "combobox",
+                    "attribute": "camb_ai_output_format",
+                    "function": "get_combobox_items",
+                    "folder_path": "",
+                    "look_for": "custom",
+                    "custom_options": ["wav", "mp3", "flac"]
+                },
+                {
+                    "label": "Enhance Named Entities",
+                    "type": "checkbox",
+                    "attribute": "camb_ai_enhance_named_entities"
+                }
+            ]
         }
     ]
 }

--- a/src/tts_engines.py
+++ b/src/tts_engines.py
@@ -38,6 +38,13 @@ except Exception as e:
     print(f"GPT-SoVITS is not available, received error: {e}")
     print("Full traceback:")
     traceback.print_exc()
+try:
+    from camb.client import CambAI, save_stream_to_file
+    from camb.types import StreamTtsOutputConfiguration
+except Exception as e:
+    print(f"Camb AI is not available, received error: {e}")
+    print("Full traceback:")
+    traceback.print_exc()
 
 def generate_audio(tts_engine, sentence, voice_parameters, tts_engine_name, audio_path):
     tts_engine_name = tts_engine_name.lower()
@@ -53,6 +60,8 @@ def generate_audio(tts_engine, sentence, voice_parameters, tts_engine_name, audi
         return generate_with_f5tts(tts_engine, sentence, voice_parameters, audio_path)
     elif tts_engine_name == 'gpt_sovits':
         return generate_with_gpt_sovits(tts_engine, sentence, voice_parameters, audio_path)
+    elif tts_engine_name == 'camb_ai':
+        return generate_with_camb_ai(tts_engine, sentence, voice_parameters, audio_path)
     else:
         # Handle unknown engine
         return False
@@ -232,7 +241,59 @@ def generate_with_gpt_sovits(tts_engine, sentence, voice_parameters, audio_path)
     sf.write(audio_path, combined_audio, sr)
     
     return audio_path
-    
+
+def generate_with_camb_ai(tts_engine, sentence, voice_parameters, audio_path):
+    import requests as camb_requests
+
+    voice_id = int(voice_parameters.get("camb_ai_voice_id", 147320))
+    language = voice_parameters.get("camb_ai_language", "en-us")
+    speech_model = voice_parameters.get("camb_ai_speech_model", "mars-flash")
+    output_format = voice_parameters.get("camb_ai_output_format", "wav")
+    enhance = voice_parameters.get("camb_ai_enhance_named_entities", False)
+    api_key = tts_engine  # load_with_camb_ai now returns the API key string
+
+    print(f"[Camb AI] Generating: '{sentence[:50]}...' voice_id={voice_id} model={speech_model}")
+    try:
+        payload = {
+            "text": sentence,
+            "language": language,
+            "voice_id": voice_id,
+            "speech_model": speech_model,
+            "output_configuration": {"format": output_format},
+            "enhance_named_entities_pronunciation": enhance,
+        }
+        resp = camb_requests.post(
+            "https://client.camb.ai/apis/tts-stream",
+            headers={
+                "x-api-key": api_key,
+                "Content-Type": "application/json",
+            },
+            json=payload,
+            stream=True,
+            timeout=120,
+        )
+        print(f"[Camb AI] Response status: {resp.status_code}")
+        if resp.status_code != 200:
+            print(f"[Camb AI] Error response: {resp.text[:500]}")
+            return False
+
+        total = 0
+        with open(audio_path, "wb") as f:
+            for chunk in resp.iter_content(chunk_size=8192):
+                if chunk:
+                    f.write(chunk)
+                    total += len(chunk)
+
+        print(f"[Camb AI] Saved {total} bytes to {audio_path}")
+        if total == 0:
+            print("[Camb AI] WARNING: Generated file is empty!")
+            return False
+        return audio_path
+    except Exception as e:
+        print(f"[Camb AI] Error generating audio: {e}")
+        traceback.print_exc()
+        return False
+
 #################################################
 ############### Loading Functions ###############
 #################################################                         
@@ -252,6 +313,8 @@ def load_tts_engine(tts_engine_name, **kwargs):
             return load_with_f5tts(**kwargs)
         elif tts_engine_name == 'gpt_sovits':
             return load_with_gpt_sovits(**kwargs)
+        elif tts_engine_name == 'camb_ai':
+            return load_with_camb_ai(**kwargs)
         else:
             # Handle unknown engine
             raise ValueError(f"Unknown TTS engine: {tts_engine_name}")
@@ -415,6 +478,12 @@ def load_with_gpt_sovits(**kwargs):
         pipeline.init_t2s_weights(t2s_ckpt_path)
         pipeline.init_vits_weights(vits_ckpt_path, vocoder_path=vocoder_path, model_version=version)
     return pipeline
+
+def load_with_camb_ai(**kwargs):
+    api_key = kwargs.get("camb_ai_api_key") or os.environ.get("CAMB_API_KEY")
+    if not api_key:
+        raise ValueError("Camb AI API key not provided. Set CAMB_API_KEY env var or enter in settings.")
+    return api_key
 
 #################################################
 ############### Utility Functions ###############


### PR DESCRIPTION
## Summary

Hi there! We're the team at Camb AI, and we'd love to be included as a TTS engine option in Audiobook Maker.

Camb AI is a voice AI and localization platform trusted by major global brands including the Premier League, the NBA, NASCAR, and the Australian Open. Our MARS model family offers high-quality text-to-speech with support for 50+ languages, voice cloning, and multiple speech models optimized for different use cases (real-time, studio-quality, and more).

This PR adds Camb AI as a new TTS engine alongside the existing options. The integration is lightweight and follows the existing config-driven pattern:

- Adds a `Camb_AI` entry to `tts_config.json` with parameters for API key, speech model, voice ID, language, and output format
- Adds `generate_with_camb_ai()` and `load_with_camb_ai()` to `tts_engines.py`
- No changes to the GUI code (controls auto-generate from config)
- Requires `pip install camb-sdk` (or `requests` as a fallback)

## How to test

1. Install the Camb AI SDK: `pip install camb-sdk`
2. Launch the app and select "Camb_AI" from the TTS engine dropdown
3. Enter a Camb AI API key (get one free at https://studio.camb.ai)
4. Select a speech model, voice ID, and language
5. Generate audio as usual

Happy to make any changes or adjustments you'd like. Thanks for building such a great tool!